### PR TITLE
Fix "no unique key prop" warning

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -547,7 +547,7 @@ var Popover = function (_React$Component) {
       );
       return [_react2.default.createElement(
         "div",
-        { className: be(className, 'trigger', [standing, isOpen ? 'isOpen' : null].concat(toArray(modifiers))) },
+        { key: "popoverTrigger", className: be(className, 'trigger', [standing, isOpen ? 'isOpen' : null].concat(toArray(modifiers))) },
         this.props.children
       ), _platform2.default.isClient && _reactDom2.default.createPortal(popover, this.props.appendTarget)];
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -512,7 +512,7 @@ class Popover extends React.Component {
       </div>
     )
     return [
-      <div className={be(className, 'trigger', [standing, isOpen ? 'isOpen' : null].concat(toArray(modifiers)))}>{this.props.children}</div>,
+      <div key='popoverTrigger' className={be(className, 'trigger', [standing, isOpen ? 'isOpen' : null].concat(toArray(modifiers)))}>{this.props.children}</div>,
       Platform.isClient &&
         ReactDOM.createPortal(popover, this.props.appendTarget),
     ]


### PR DESCRIPTION
Before it threw annoying `Warning: Each child in an array or iterator should have a unique "key" prop. See https://fb.me/react-warning-keys for more information.` on each render.